### PR TITLE
ERROR: Ignored the following versions that require a different python version: 0.1.1 Requires-Python >=3.12; 0.1.3 Requires-Python >=3.12 ERROR: Could not find a version that satisfies the requirement pubmedmcp>=0.1.3 (from versions: none) ERROR: No matching distribution found for pubmedmcp>=0.1.3

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,7 @@ else
 fi
 
 # --- Configuration Variables ---
-PYTHON_CMD="python3"
+PYTHON_CMD="python3.12"
 VENV_DIR="venv"
 MCP_JSON_FILE="mcp.json"
 MODELS_DIR="models"


### PR DESCRIPTION
Description:

The current setup.sh script installs Python 3.11 by default, which leads to dependency issues with certain modules that require Python 3.12 or higher. For example, the pubmedmcp>=0.1.3 package cannot be installed due to version incompatibility:

```
ERROR: Ignored the following versions that require a different python version: 0.1.1 Requires-Python >=3.12; 0.1.3 Requires-Python >=3.12
ERROR: Could not find a version that satisfies the requirement pubmedmcp>=0.1.3 (from versions: none)
ERROR: No matching distribution found for pubmedmcp>=0.1.3
```

To fix this, the setup.sh script has been updated to explicitly use Python 3.12. This ensures compatibility with required dependencies and prevents installation failures.