### PR TITLE
Feature/add ollama support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,7 @@ PRIMARY_MODEL_TYPE: "gemini"
 # The system will use the model that corresponds to the selected PRIMARY_MODEL_TYPE.
 CLAUDE_MODEL_NAME: "claude-3-7-sonnet-20250219"
 GEMINI_MODEL_NAME: "gemini-2.5-pro-preview-03-25"
+OLLAMA_MODEL_NAME: "llama3.2"
 LOCAL_MODEL_NAME: null
 LOCAL_MODEL_QUANT_LEVEL: null
 # --- Local Model Usage ---

--- a/config/settings.py
+++ b/config/settings.py
@@ -29,6 +29,7 @@ DEFAULT_CONFIG = {
     # --- Local Model Configuration --- #
     "LOCAL_MODELS_DIR": "models",  # Directory for storing local models
     "N_GPU_LAYERS": -1, # Number of layers to offload to GPU (-1 = try all)
+    "OLLAMA_SERVER_URL": "http://localhost:11434", # Default Ollama server URL
 
     # --- Content Management Settings --- #
     "USE_PROGRESSIVE_LOADING": True,

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,8 @@ langchain-community==0.3.22
 langchain-core==0.3.55
 langchain-text-splitters==0.3.8
 langchain-mcp-adapters==0.0.9
-
+langchain-ollama==0.3.2
+ollama==0.4.8
 # Optional LangChain for local models (uncomment if using local LLMs)
 # langchain-huggingface>=0.1.0
 

--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,7 @@ else
 fi
 
 # --- Configuration Variables ---
-PYTHON_CMD="python3.12"
+PYTHON_CMD="python3"
 VENV_DIR="venv"
 MCP_JSON_FILE="mcp.json"
 MODELS_DIR="models"

--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,7 @@ else
 fi
 
 # --- Configuration Variables ---
-PYTHON_CMD="python3"
+PYTHON_CMD="python3.12"
 VENV_DIR="venv"
 MCP_JSON_FILE="mcp.json"
 MODELS_DIR="models"


### PR DESCRIPTION
# Ollama Integration for CleverBee

## Overview

This pull request adds native support for Ollama models to CleverBee, allowing the application to connect to a local or remote Ollama server for LLM inference. This integration enables users to work with various open-source models through Ollama's simple API without requiring direct model file management.

## Changes

1. **Added Ollama as a provider type in `factory.py`**
   - Added "ollama" to ProviderType enum
   - Added import for ChatOllama from langchain_ollama
   - Implemented a dedicated Ollama client creation function

2. **Updated configuration files**
   - Added OLLAMA_SERVER_URL to config.yaml
   - Added OLLAMA_MODEL_NAME to config.yaml
   - Added Ollama server URL as default parameter in settings.py
   - Added Ollama handling to PRIMARY_MODEL_TYPE logic in settings.py

3. **Enhanced documentation**
   - Updated comments for clarity on using Ollama models
   - Added descriptive error messages for Ollama connection issues

## Benefits

- **Simplified Model Deployment**: Use models without downloading large GGUF files directly
- **Remote Model Support**: Connect to models hosted on remote Ollama servers
- **Wider Model Selection**: Access any model available in Ollama's ecosystem
- **Reduced Configuration Complexity**: No need for GPU layer configuration or GGUF file management

## How to Use

1. Set `PRIMARY_MODEL_TYPE: "ollama"` in config.yaml
2. Set `OLLAMA_MODEL_NAME: "model_name"` to your preferred model (e.g., "llama3", "codellama", etc.)
3. Configure `OLLAMA_SERVER_URL` to point to your Ollama server (default: "http://localhost:11434")
4. Ensure Ollama is running and has the specified model installed

## Requirements

- Ollama installed and running (locally or remotely)
- Required Python package: `langchain-ollama` 